### PR TITLE
Validated generic aarch64 -march target

### DIFF
--- a/xlibre-xf86-input-elographics/PKGBUILD
+++ b/xlibre-xf86-input-elographics/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-input-evdev/PKGBUILD
+++ b/xlibre-xf86-input-evdev/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-input-libinput/PKGBUILD
+++ b/xlibre-xf86-input-libinput/PKGBUILD
@@ -26,7 +26,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-input-libinput/PKGBUILD-1.5.0.1
+++ b/xlibre-xf86-input-libinput/PKGBUILD-1.5.0.1
@@ -25,7 +25,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-input-synaptics/PKGBUILD
+++ b/xlibre-xf86-input-synaptics/PKGBUILD
@@ -27,7 +27,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-input-vmmouse/PKGBUILD
+++ b/xlibre-xf86-input-vmmouse/PKGBUILD
@@ -23,7 +23,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-input-void/PKGBUILD
+++ b/xlibre-xf86-input-void/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-input-wacom/PKGBUILD
+++ b/xlibre-xf86-input-wacom/PKGBUILD
@@ -32,7 +32,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-amdgpu/PKGBUILD
+++ b/xlibre-xf86-video-amdgpu/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-ati/PKGBUILD
+++ b/xlibre-xf86-video-ati/PKGBUILD
@@ -31,7 +31,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-dummy/PKGBUILD
+++ b/xlibre-xf86-video-dummy/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-fbdev/PKGBUILD
+++ b/xlibre-xf86-video-fbdev/PKGBUILD
@@ -23,7 +23,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-intel/PKGBUILD
+++ b/xlibre-xf86-video-intel/PKGBUILD
@@ -41,7 +41,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-nouveau/PKGBUILD
+++ b/xlibre-xf86-video-nouveau/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-qxl/PKGBUILD
+++ b/xlibre-xf86-video-qxl/PKGBUILD
@@ -25,7 +25,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-sisusb/PKGBUILD
+++ b/xlibre-xf86-video-sisusb/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-vesa/PKGBUILD
+++ b/xlibre-xf86-video-vesa/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-vmware/PKGBUILD
+++ b/xlibre-xf86-video-vmware/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xf86-video-voodoo/PKGBUILD
+++ b/xlibre-xf86-video-voodoo/PKGBUILD
@@ -24,7 +24,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"

--- a/xlibre-xserver/PKGBUILD
+++ b/xlibre-xserver/PKGBUILD
@@ -41,7 +41,7 @@ build() {
       CFLAGS=" -march=x86-64"
       ;;
     "aarch64")
-      CFLAGS=" -march=aarch64"
+      CFLAGS=" -march=armv8-a"
       ;;
     *)
       CFLAGS=" -march=native"


### PR DESCRIPTION
This pull request changes `-march=aarch64` to `-march-armv8-a`, the latter of
which is a generic target for the aarch64 (arm64) architecture. See gcc's
documentation on aarch64 for more details.
(https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html).