### PR TITLE
fix(xserver): add missing dependency libbsd in pkgbuild

### DIFF
--- a/xlibre-xserver/PKGBUILD
+++ b/xlibre-xserver/PKGBUILD
@@ -125,7 +125,7 @@ package_xlibre-xserver() {
   pkgdesc="XLibre fork of X.Org X server"
   depends=(xlibre-xserver-common xlibre-input-libinput libepoxy libxfont2 pixman libunwind
            dbus libgl nettle libxdmcp sh glibc libxau libtirpc libmd
-           libpciaccess libdrm libxshmfence libxcvt) # FS#52949
+           libpciaccess libdrm libxshmfence libxcvt libbsd) # FS#52949
   # see xorg-server-*/hw/xfree86/common/xf86Module.h for ABI versions - we provide major numbers that drivers can depend on
   # and /usr/lib/pkgconfig/xorg-server.pc in xorg-server-devel pkg
   provides=('xorg-server' 'X-ABI-VIDEODRV_VERSION=28.0' 'X-ABI-XINPUT_VERSION=26.0' 'X-ABI-EXTENSION_VERSION=11.0' 'x-server')


### PR DESCRIPTION
Without `libbsd` installed, xserver fails to start `libbsd.so no such file or directory`

See `namcap xlibre-xserver-25.0.0.16-1-x86_64.pkg.tar.zst`

```
xlibre-xserver E: Dependency libbsd detected and not included (libraries ['usr/lib/libbsd.so.0'] needed in files ['usr/lib/xorg/modules/xlibre-25.0/extensions/libglx.so', 'usr/lib/Xorg', 'usr/lib/xorg/modules/xlibre-25.0/libglamoregl.so'])
```