### PR TITLE
README.md: Fix the incorrect instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These are available in a separate xlibre repository which can be enabled with th
   `sudo pacman-key --lsign-key 73580DE2EDDFA6D6`
 * Add the xlibre repository by adding this section to file /etc/pacman.conf:\
   `[xlibre]`\
-  `Server = https://x11libre.net/repo/arch_based/x86_64/`\
+  `Server = https://x11libre.net/repo/arch_based/$arch/`\
   `# List of available packages: https://github.com/X11Libre/pkgbuilds-arch-based`
 
 


### PR DESCRIPTION
 - Do not use `sudo curl`, it's result is piped to `pacman-key` so run `curl` as root doesnt do anything more than as a normal user.
 - Use `pacman-key --add` instead of `gpg -- import`, which is simply wrong. Also `pacman-key` is a command only supposed to be ran as root.(Import the key into a normal user's gpg keystore doesnt do anything useful)
 - Even though there're no archlinuxarm support currently, using `$arch` instead of `x86_64` is always the perferred way
 - (Currently the gpg key is put in the path `repo/arch_based/x86_64/`, I would suggest putting it under `repo/arch_based/` like most other arch package repos do.)