### PR TITLE
`install-xlibre.sh`: Use POSIX `$(id -u)` instead of `$EUID`

### DIFF
--- a/install-xlibre.sh
+++ b/install-xlibre.sh
@@ -19,7 +19,7 @@
 
 PACMAN_CONFIRMATION=${PACMAN_CONFIRMATION:-true}
 
-if [ $EUID -ne 0 ]; then
+if [ $(id -u) -ne 0 ]; then
   if command -v doas 1>/dev/null; then
     runasroot=doas
   elif command -v sudo 1>/dev/null; then


### PR DESCRIPTION
Just saw that `$EUID` is not POSIX, as this targets `/bin/sh`, `$(id -u)` should be used instead.